### PR TITLE
HashSerializer

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -1,5 +1,6 @@
 require 'thread_safe'
 require 'jsonapi/include_directive'
+require 'active_model/serializer/hash_serializer'
 require 'active_model/serializer/collection_serializer'
 require 'active_model/serializer/array_serializer'
 require 'active_model/serializer/error_serializer'

--- a/lib/active_model/serializer/hash_serializer.rb
+++ b/lib/active_model/serializer/hash_serializer.rb
@@ -1,0 +1,73 @@
+module ActiveModel
+  class Serializer
+    class HashSerializer
+      include Enumerable
+      delegate :each, :keys, :values, to: :@serializer_hash
+
+      attr_reader :object, :root
+
+      def initialize(object, options={})
+        @object  = object
+        @options = options
+        @root    = options[:root]
+        @serializer_hash = to_serializable_values(object, options)
+        @serializer_values = @serializer_hash.values.select { |v| v.is_a?(ActiveModel::Serializer) }
+      end
+
+      def success?
+        true
+      end
+
+      def serializable_hash(adapter_options = nil, options = {}, adapter_instance = self.class.serialization_adapter_instance)
+        adapter_options ||= {}
+        include_directive = ActiveModel::Serializer.include_directive_from_options(adapter_options)
+        adapter_options[:cached_attributes] ||= ActiveModel::Serializer.cache_read_multi(@serializer_values, adapter_instance, include_directive)
+        adapter_options_with_include = adapter_options.merge(include_directive: include_directive)
+        @serializer_hash.each_with_object({}) do |(key, value), output|
+          output[key] = if value.respond_to?(:serializable_hash)
+            value.serializable_hash(adapter_options_with_include, options, adapter_instance) || value
+          else
+            value
+          end
+        end
+      end
+      alias to_hash serializable_hash
+      alias to_h serializable_hash
+
+      def json_key
+        root
+      end
+
+      def as_json(adapter_options = nil)
+        serializable_hash(adapter_options)
+      end
+
+      def self.serialization_adapter_instance
+        @serialization_adapter_instance ||= ActiveModelSerializers::Adapter::Attributes
+      end
+
+      private
+
+      def to_serializable_values(object, options)
+        serializer_context_class = options.fetch(:serializer_context_class, ActiveModel::Serializer)
+        object.each_with_object({}) do |(key, value), output|
+          output[key] = serializer_for_resource(value, serializer_context_class, options) || value
+        end
+      end
+    
+      def serializer_for_resource(resource, serializer_context_class, options)
+        serializer_class = serializer_context_class.serializer_for(resource, namespace: options[:namespace])
+        return unless serializer_class.present?
+    
+        catch(:no_serializer) do
+          if serializer_class == ActiveModel::Serializer::CollectionSerializer && options[:uniform_collection] && !resource.empty?
+            element_serializer = serializer_context_class.serializer_for(resource.first, namespace: options[:namespace])
+            serializer_class.new(resource, options.merge(serializer: element_serializer))
+          else
+            serializer_class.new(resource, options.except(:serializer))
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/hash_serializer_test.rb
+++ b/test/hash_serializer_test.rb
@@ -1,0 +1,98 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class HashSerializerTest < ActiveSupport::TestCase
+      class SingularModel < ::Model
+        attributes :id, :name
+      end
+      class SingularModelSerializer < ActiveModel::Serializer
+        attributes :id, :name
+      end
+      class HasManyModel < ::Model
+        associations :singular_models
+      end
+      class HasManyModelSerializer < ActiveModel::Serializer
+        has_many :singular_models
+
+        def custom_options
+          instance_options
+        end
+      end
+
+      def setup
+        @singular_model = SingularModel.new
+        @has_many_model = HasManyModel.new
+        @resource = {
+          single: @singular_model,
+          many:   @has_many_model
+        }
+        @serializer = HashSerializer.new(@resource, some: :options)
+      end
+
+      def test_has_object_reader_serializer_interface
+        assert_equal @serializer.object, @resource
+      end
+
+      def test_respond_to_each
+        assert_respond_to @serializer, :each
+      end
+
+      def test_each_object_should_be_serialized_with_appropriate_serializer
+        serializers =  @serializer.values
+
+        assert_kind_of SingularModelSerializer, serializers.first
+        assert_kind_of SingularModel, serializers.first.object
+
+        assert_kind_of HasManyModelSerializer, serializers.last
+        assert_kind_of HasManyModel, serializers.last.object
+
+        assert_equal :options, serializers.last.custom_options[:some]
+      end
+
+      def test_serializer_option_not_passed_to_each_serializer
+        serializers = HashSerializer.new({ many: @has_many_model }, serializer: HasManyModelSerializer).values
+
+        refute serializers.first.custom_options.key?(:serializer)
+      end
+
+      def test_serializer_option_set_to_uniform_collection_sub_serializer
+        serializers = HashSerializer.new({ many: [@has_many_model] }, serializer: SingularModelSerializer, uniform_collection: true).values
+
+        assert_equal serializers.first.instance_variable_get(:@options)[:serializer], HasManyModelSerializer
+      end
+
+      def test_root
+        expected = 'custom_root'
+        @serializer = HashSerializer.new({ single: @singular_model, many: @has_many_model }, root: expected)
+        assert_equal expected, @serializer.root
+      end
+
+      def test_json_key_with_root
+        expected = 'custom_root'
+        @serializer = HashSerializer.new({ single: @singular_model, many: @has_many_model }, root: expected)
+        assert_equal expected, @serializer.json_key
+      end
+
+      def test_as_json
+        expected = {
+          value: 123,
+          single: {id: 1, name: 'name'},
+          many: {
+            singular_models: [
+              {id: 2, name: 'mena'}
+            ]
+          },
+          array: [
+            {id: 1, name: 'name'},
+            {id: 2, name: 'mena'}
+          ]
+        }
+        single_1 = SingularModel.new(id: 1, name: 'name')
+        single_2 = SingularModel.new(id: 2, name: 'mena')
+        @serializer = HashSerializer.new({ value: 123, single: single_1, many: HasManyModel.new(singular_models: [single_2]), array: [single_1, single_2] }, root: expected)
+        assert_equal expected, @serializer.as_json
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Invisible to serializer_for method
  * One needs to new HashSerializer every time
  * The main reason is that Collection => Hash won't work correctly for now and cause tests to fail
* Set option `uniform_collection: true` so that HashSerializer check array values' first element only and assume that all the rest should use then same serializer
* int or string values work fine, no exception will be thrown
  * But be ware that values without suitable serializers will also be accepted and cause maybe unexpected output